### PR TITLE
Duplicate Status, Project and Priority in Admin section when XObject on page with localization variants #181

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/AdministrationAddProject.xml
+++ b/application-task-ui/src/main/resources/TaskManager/AdministrationAddProject.xml
@@ -71,7 +71,7 @@
     'rowCount' : 15,
     'description' : 'This table lists all projects configured within the Task Application.',
     'className' : 'TaskManager.ProjectClass',
-    'queryFilters': ' '
+    'queryFilters': 'unique'
   })
 #livetable("projectTable" $columns $columnsProperties $options)
 #else

--- a/application-task-ui/src/main/resources/TaskManager/AdministrationAddSeverity.xml
+++ b/application-task-ui/src/main/resources/TaskManager/AdministrationAddSeverity.xml
@@ -71,7 +71,7 @@
     'rowCount' : 15,
     'description' : 'This table lists all severities that can be assigned to a task.',
     'className' : 'TaskManager.SeverityClass',
-    'queryFilters': ' '
+    'queryFilters': 'unique'
   })
 #livetable("severityTable" $columns $columnsProperties $options)
 #else

--- a/application-task-ui/src/main/resources/TaskManager/AdministrationAddStatus.xml
+++ b/application-task-ui/src/main/resources/TaskManager/AdministrationAddStatus.xml
@@ -77,7 +77,7 @@
     'rowCount' : 15,
     'description' : 'This table lists all the statuses that a task can have.',
     'className' : 'TaskManager.StatusClass',
-    'queryFilters': ' '
+    'queryFilters': 'unique'
   })
 #livetable("statusTable" $columns $columnsProperties $options)
 #else


### PR DESCRIPTION
Added unique query filter to prevent multiple of the same document appearing in a list when it has translations/localization variants.

Duplicates can still happen if a document has multiple TaskManager.StatusClass objects.